### PR TITLE
Show preview of figures in Jupyter

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ plt.show()
 Now that we have finally reproduced the plot in pgf we show how to import it in a LaTeX document. It is really straightforward, using the `pgfplots` package. We make an example of the following here:
 
 ```latex
+\documentclass{article}
+
+\usepackage{pgfplots} %To import .pgf images
+
+\begin{document}
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 \begin{figure}
     \centering
@@ -87,6 +92,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
     \caption{Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.}
     \label{fig:trial}
 \end{figure}
+\end{document}
 ```
 
 which gives the following output. It is a little blurred, but you can look at the original `.pdf` in the folder `Examples_files`

--- a/mpl2latex.py
+++ b/mpl2latex.py
@@ -72,7 +72,8 @@ class mpl2latex():
     """
     
     def __init__(self, back_flag, packages = None, backend='pgf'):
-
+        import subprocess; subprocess.check_call(["latex", "-help"])
+        
         self.back_flag = back_flag
         self.original_backend = matplotlib.pyplot.get_backend()
         self.original_rcParams = matplotlib.rcParams
@@ -95,7 +96,6 @@ class mpl2latex():
                 'pgf.rcfonts': False,
                 "pgf.preamble": "\n".join( self.packages ),
             })
-            matplotlib.use( self.backend )
 
 
     def __exit__(self, etype, value, traceback):
@@ -103,9 +103,8 @@ class mpl2latex():
         """
         # --- reset rcParams ---
         matplotlib.rcParams.update( self.original_rcParams )
-        # --- reset backend ---
-        matplotlib.use( self.original_backend )
-        
+        matplotlib.rcParams.update({ 'text.usetex' : False }) #Manually disable latex
+
 def latex_figsize(wf=0.5, hf=(5.**0.5-1.0)/2.0, columnwidth=510):
     """
         Get the correct figure size to be displayed in a latex report/publication


### PR DESCRIPTION
Apparently `matplotlib.use('pgf')` is not necessary. That is, if we leave the default backend, the plot will be correctly saved in `.pgf`, with no change in content. However, since the original backend has a GUI, a preview will be shown in the Jupyter notebook, which is useful.
Also, I think it's good to disable LaTeX rendering when outside the context, so that plotting is quicker. To do so, one has to explicitly set the `text.usetex` to `False`. Resetting to the original `rcParams` does not suffice.

Finally, I've added a few lines of tex to the docs, so that the example can be immediately compiled. For instance, one needs to import `pgfplots` to add `.pgf` files to a LaTeX document.